### PR TITLE
Remove upfront authentication

### DIFF
--- a/app/controllers/experiences_controller.rb
+++ b/app/controllers/experiences_controller.rb
@@ -1,5 +1,5 @@
 class ExperiencesController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :show, :search]
+  skip_before_action :authenticate_user!, only: [:index, :show, :search]
 
   def index
     @experiences = Experience.all

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,5 +1,5 @@
 class RestaurantsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :show, :search]
+  skip_before_action :authenticate_user!, only: [:index, :show, :search]
 
   def index
     @restaurants = Restaurant.all

--- a/app/views/experiences/index.html.erb
+++ b/app/views/experiences/index.html.erb
@@ -3,8 +3,10 @@
 
     <div class="flex flex-col min-h-screen">
       <div class="flex justify-between items-center p-4 bg-white shadow-sm">
-      <%= link_to destroy_user_session_path,  data: { turbo_method: :delete }, class: "z-10 bg-white rounded-full p-2" do %>
-          <i class="fa-solid fa-right-from-bracket"></i>
+        <% if user_signed_in? %>
+          <%= link_to destroy_user_session_path,  data: { turbo_method: :delete }, class: "z-10 bg-white rounded-full p-2" do %>
+            <i class="fa-solid fa-right-from-bracket"></i>
+          <% end %>
         <% end %>
 
         <div data-controller="modal" class="w-full">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <%= tag.link rel: "icon", href: image_url("app-icon-512.png"), type: "image/png" %>
     <%= tag.link rel: "apple-touch-icon", href: image_url("app-icon-512.png") %>
 
-<%= csrf_meta_tags %>
+    <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.1.2/css/all.css">
@@ -19,7 +19,5 @@
 
   <body class="flex flex-col min-h-screen">
     <%= yield %>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
   </body>
 </html>

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -3,10 +3,12 @@
 
     <div class="flex flex-col min-h-screen">
       <div class="flex justify-between items-center p-4 bg-white shadow-sm">
-      <%= link_to destroy_user_session_path,  data: { turbo_method: :delete }, class: "z-10 bg-white rounded-full p-2" do %>
-          <i class="fa-solid fa-right-from-bracket"></i>
+        <% if user_signed_in? %>
+          <%= link_to destroy_user_session_path,  data: { turbo_method: :delete }, class: "z-10 bg-white rounded-full p-2" do %>
+            <i class="fa-solid fa-right-from-bracket"></i>
+          <% end %>
         <% end %>
-
+        
         <div data-controller="modal" class="w-full">
           <div class="relative z-20 hidden" data-modal-target="dialog" aria-labelledby="modal-title" role="dialog" aria-modal="true">
             <div class="fixed inset-0 bg-black/80 transition-opacity" aria-hidden="true"></div>


### PR DESCRIPTION
Hello Ivy!

This should do the trick to allow users to use the app without an account and then prompting them to create one if they want to make a reservation.